### PR TITLE
optionally override version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ properties([
   parameters([
     booleanParam(defaultValue: false, description: 'Force Red Hat Certified Build for a non-master branch', name: 'force_red_hat_build'),
     booleanParam(defaultValue: false, description: 'Skip Red Hat Certified Build', name: 'skip_red_hat_build'),
+    string(defaultValue: '', description: 'Override automatic version assignment', name: 'version')
   ])
 ])
 
@@ -26,7 +27,7 @@ node('ubuntu-zion') {
 
     isMaster = checkoutDetails.GIT_BRANCH in ['origin/master', 'master']
 
-    version = readVersion()
+    version = params.version ?: readVersion()
   }
 
   stage('Trigger Red Hat Certified Image Build') {

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -107,6 +107,10 @@ class BuildClient {
   * @return the full new version string to submit for the next build
   */
   private String getNextTag(String version) {
+    if (version =~ /.*-.*/) {
+      return version
+    }
+
     final tags = getTags()*.name.collectMany {
       it.split(', ').collect()
     }


### PR DESCRIPTION
when red hat's build service just drops a build on the floor half done in the scanning queue, our build wouldn't figure out the next version, but the build service wouldn't let us build/scan the same version. In those cases, we can now override with a full tag (3.28.0-2) instead of a partial tag which will still be auto-completed by the script.

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/operator-nxrm3/job/feature-snapshots/job/force-operator-version/