### PR TITLE
add ability for additional service ports to be added as ports on the deployment/statefulset ports.

### DIFF
--- a/helm-charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/helm-charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -82,6 +82,12 @@ spec:
               name: nexus-docker-g
             - containerPort: {{ .Values.nexus.nexusPort }}
               name: nexus-http
+{{- if .Values.service.enabled -}}
+{{- range .Values.service.ports }}
+            - containerPort: {{ .targetPort }}
+              name: {{ .name }}
+{{- end}}
+{{- end}}
           livenessProbe:
             httpGet:
               path: {{ .Values.nexus.livenessProbe.path }}


### PR DESCRIPTION
# Purpose
possible solution for issue #26.

# possible issues
* this defaults to always creating any additional service ports as pod ports
  - could keep this as is, i can't think of why you would add an extra service port and not expose the port on the pod
  - could add a flag to say whether to expose the port in the pod
  - could use a completly different dictionary from the `service` dictionary to speicy the pod ports
* there is a 15 character limit on pod port names that can cause issues
  - not sure how to deal with this one

# testing
I have tested this in my environment and it works.
