### PR TITLE
INT-5337 eliminate fsGroup that causes failures

### DIFF
--- a/helm-charts/sonatype-nexus/values.yaml
+++ b/helm-charts/sonatype-nexus/values.yaml
@@ -49,7 +49,6 @@ nexus:
     periodSeconds: 30
   resources: {}
   securityContext:
-    fsGroup: 2000
 nexusProxyRoute:
   annotations: null
   enabled: false

--- a/scripts/templates/nxrm-operator-certified.vX.X.X-X.clusterserviceversion.yaml
+++ b/scripts/templates/nxrm-operator-certified.vX.X.X-X.clusterserviceversion.yaml
@@ -74,7 +74,6 @@ metadata:
               },
               "resources": {},
               "securityContext": {
-                "fsGroup": 2000
               },
               "service": {
                 "type": "NodePort"
@@ -192,7 +191,7 @@ spec:
     | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
     | `nexus.service.type`                        | Service for Nexus                   |`NodePort`                                |
     | `nexus.service.clusterIp`                   | Specific cluster IP when service type is cluster IP. Use None for headless service |`nil`   |
-    | `nexus.securityContext`                     | Security Context (for enabling official image use `fsGroup: 2000`) | `{}`     |
+    | `nexus.securityContext`                     | Security Context |
     | `nexus.labels`                              | Service labels                      | `{}`                                    |
     | `nexus.podAnnotations`                      | Pod Annotations                     | `{}`
     | `nexus.livenessProbe.initialDelaySeconds`   | LivenessProbe initial delay         | 30                                      |

--- a/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+++ b/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
@@ -56,7 +56,6 @@ spec:
       periodSeconds: 30
     resources: {}
     securityContext:
-      fsGroup: 2000
   nexusProxyRoute:
     annotations: null
     enabled: false

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -49,7 +49,6 @@ nexus:
     periodSeconds: 30
   resources: {}
   securityContext:
-    fsGroup: 2000
 nexusProxyRoute:
   annotations: null
   enabled: false


### PR DESCRIPTION
remove the default fsGroup that is no longer appropriate for newer openshift

JIRA: https://issues.sonatype.org/browse/INT-5337
Jenkins:  https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/operator-nxrm3/job/feature-snapshots/job/INT-5337-deployment-fixes/