### PR TITLE
INT-5337 upgrade 3.31.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/operator-framework/helm-operator:v1.5.0
 # Required OpenShift Labels
 LABEL name="Nexus Repository Operator" \
       vendor="Sonatype" \
-      version="3.30.0" \
+      version="3.31.1" \
       release="1" \
       summary="The Nexus Repository Manager with universal support for popular component formats." \
       description="The Nexus Repository Manager with universal support for popular component formats."

--- a/deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+++ b/deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
@@ -39,7 +39,7 @@ spec:
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "false"
     hostAliases: []
-    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.30.0-ubi-1
+    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.31.1-ubi-2
     imagePullPolicy: IfNotPresent
     imagePullSecret: ""
     livenessProbe:
@@ -56,7 +56,6 @@ spec:
       periodSeconds: 30
     resources: {}
     securityContext:
-      fsGroup: 2000
   nexusProxyRoute:
     annotations: null
     enabled: false

--- a/deploy/olm-catalog/nxrm-operator-certified/3.31.1-1/nxrm-operator-certified.v3.31.1-1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/3.31.1-1/nxrm-operator-certified.v3.31.1-1.clusterserviceversion.yaml
@@ -1,0 +1,379 @@
+# DO NOT MODIFY. This is produced by template.
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "sonatype.com/v1alpha1",
+          "kind": "NexusRepo",
+          "metadata": {
+            "name": "example-nexusrepo"
+          },
+          "spec": {
+            "config": {
+              "data": null,
+              "enabled": false,
+              "mountPath": "/sonatype-nexus-conf"
+            },
+            "deployment": {
+              "additionalContainers": null,
+              "additionalVolumeMounts": null,
+              "additionalVolumes": null,
+              "annotations": {},
+              "initContainers": null,
+              "postStart": {
+                "command": null
+              },
+              "preStart": {
+                "command": null
+              },
+              "terminationGracePeriodSeconds": 120
+            },
+            "deploymentStrategy": {},
+            "ingress": {
+              "annotations": {},
+              "enabled": false,
+              "path": "/",
+              "rules": null,
+              "tls": {
+                "enabled": true,
+                "secretName": "nexus-tls"
+              }
+            },
+            "nexus": {
+              "dockerPort": 5003,
+              "env": [
+                {
+                  "name": "install4jAddVmParams",
+                  "value": "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+                },
+                {
+                  "name": "NEXUS_SECURITY_RANDOMPASSWORD",
+                  "value": "false"
+                }
+              ],
+              "hostAliases": [],
+              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager:3.31.1-ubi-2",
+              "imagePullPolicy": "IfNotPresent",
+              "imagePullSecret": "",
+              "livenessProbe": {
+                "failureThreshold": 6,
+                "initialDelaySeconds": 30,
+                "path": "/",
+                "periodSeconds": 30
+              },
+              "nexusPort": 8081,
+              "podAnnotations": {},
+              "readinessProbe": {
+                "failureThreshold": 6,
+                "initialDelaySeconds": 30,
+                "path": "/",
+                "periodSeconds": 30
+              },
+              "resources": {},
+              "securityContext": {
+              },
+              "service": {
+                "type": "NodePort"
+              }
+            },
+            "nexusProxyRoute": {
+              "annotations": null,
+              "enabled": false,
+              "labels": null
+            },
+            "persistence": {
+              "accessMode": "ReadWriteOnce",
+              "enabled": true,
+              "storageSize": "8Gi"
+            },
+            "replicaCount": 1,
+            "route": {
+              "annotations": null,
+              "enabled": false,
+              "labels": null,
+              "name": "docker",
+              "portName": "docker"
+            },
+            "secret": {
+              "data": null,
+              "enabled": false,
+              "mountPath": "/etc/secret-volume",
+              "readOnly": true
+            },
+            "service": {
+              "annotations": {},
+              "enabled": false,
+              "labels": {},
+              "ports": [
+                {
+                  "name": "nexus-service",
+                  "port": 80,
+                  "targetPort": 80
+                }
+              ]
+            },
+            "statefulset": {
+              "enabled": false
+            },
+            "tolerations": []
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: "Integration & Delivery"
+    description: |-
+      Nexus Repository is the central source of control to efficiently manage all binaries
+      and build artifacts across your DevOps pipeline.
+    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.31.1-1
+    repository: https://github.com/sonatype/operator-nxrm3
+    createdAt: 2020-07-17
+    support: Sonatype
+    certified: "true"
+  name: nxrm-operator-certified.v3.31.1-1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: Nexus Repository
+        displayName: NexusRepo
+        kind: NexusRepo
+        name: nexusrepos.sonatype.com
+        version: v1alpha1
+  description: |-
+    Nexus Repository is the central source of control to efficiently manage all binaries
+    and build artifacts across your DevOps pipeline.
+    The flow of open source and third-party components into and through an organization
+    creates a complex software supply chain.
+    Nexus Repository delivers speed, efficiency, and quality to the governance
+    and management of all dependencies, libraries, and applications for your DevOps teams.
+
+    ## Core Capabilities
+
+    * **Dependency Management**:
+      Improves reliability with repeatable, fast access to secure dependencies
+    * **Developer Productivity**:
+      Streamline developer workflows by enabling the sharing of components and applications across teams
+    * **Supply Chain Performance**:
+      Improve speed-to-market and reduced build times with release advanced staging and component tagging
+    * **CI/CD Integrations**:
+      Increase DevOps scalability with integrations to the most popular build and deployment tools
+
+    Version control systems and package registries do not scale when managing proprietary,
+    open source, and third-party components.
+    Organizations need a central binary and build artifact repository to manage dependencies
+    across the entire software supply chain.
+
+    ## Limitations
+
+    High Availability Clustering (HA-C) is not supported for Nexus Repository Pro for OpenShift.
+
+    ## Usage
+
+    Once the server instance is created by the operator and running,
+    you'll want to expose the service as you see fit:
+    1. Create a Route to that service for nexus.port (8081).
+
+    By default, the Nexus Repository starts up in OSS mode until a license is installed.
+
+    The Nexus Repository can be further configured via the NexusRepo custom resource definition:
+
+    | Parameter                                   | Description                         | Default                                 |
+    | ------------------------------------------  | ----------------------------------  | ----------------------------------------|
+    | `statefulset.enabled`                       | Use statefulset instead of deployment | `false` |
+    | `deploymentStrategy`                        | Deployment Strategy     |  `rollingUpdate` |
+    | `nexus.env`                                 | Nexus environment variables         | `[{install4jAddVmParams: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}]` |
+    | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
+    | `nexus.dockerPort`                          | Port to access docker               | `5003`                                  |
+    | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
+    | `nexus.service.type`                        | Service for Nexus                   |`NodePort`                                |
+    | `nexus.service.clusterIp`                   | Specific cluster IP when service type is cluster IP. Use None for headless service |`nil`   |
+    | `nexus.securityContext`                     | Security Context |
+    | `nexus.labels`                              | Service labels                      | `{}`                                    |
+    | `nexus.podAnnotations`                      | Pod Annotations                     | `{}`
+    | `nexus.livenessProbe.initialDelaySeconds`   | LivenessProbe initial delay         | 30                                      |
+    | `nexus.livenessProbe.periodSeconds`         | Seconds between polls               | 30                                      |
+    | `nexus.livenessProbe.failureThreshold`      | Number of attempts before failure   | 6                                       |
+    | `nexus.livenessProbe.timeoutSeconds`        | Time in seconds after liveness probe times out    | `nil`                     |
+    | `nexus.livenessProbe.path`                  | Path for LivenessProbe              | /                                       |
+    | `nexus.readinessProbe.initialDelaySeconds`  | ReadinessProbe initial delay        | 30                                      |
+    | `nexus.readinessProbe.periodSeconds`        | Seconds between polls               | 30                                      |
+    | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
+    | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
+    | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
+    | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
+    | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
+    | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
+    | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
+    | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
+    | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+    | `tolerations`                               | tolerations list                    | `[]`                                    |
+    | `config.enabled`                            | Enable configmap                    | `false`                                 |
+    | `config.mountPath`                          | Path to mount the config            | `/sonatype-nexus-conf`                  |
+    | `config.data`                               | Configmap data                      | `nil`                                   |
+    | `deployment.terminationGracePeriodSeconds`  | Time to allow for clean shutdown    | 120                                     |
+    | `deployment.annotations`                    | Annotations to enhance deployment configuration  | `{}`                       |
+    | `deployment.initContainers`                 | Init containers to run before main containers  | `nil`                        |
+    | `deployment.postStart.command`              | Command to run after starting the nexus container  | `nil`                    |
+    | `deployment.preStart.command`               | Command to run before starting the nexus container  | `nil`                   |
+    | `deployment.additionalContainers`           | Add additional Container         | `nil`                                      |
+    | `deployment.additionalVolumes`              | Add additional Volumes           | `nil`                                      |
+    | `deployment.additionalVolumeMounts`         | Add additional Volume mounts     | `nil`                                      |
+    | `secret.enabled`                            | Enable secret                    | `false`                                    |
+    | `secret.mountPath`                          | Path to mount the secret         | `/etc/secret-volume`                       |
+    | `secret.readOnly`                           | Secret readonly state            | `true`                                     |
+    | `secret.data`                               | Secret data                      | `nil`                                      |
+    | `service.enabled`                           | Enable additional service        | `nil`                                      |
+    | `service.name`                              | Service name                     | `nil`                                      |
+    | `service.portName`                          | Service port name                | `nil`                                      |
+    | `service.labels`                            | Service labels                   | `nil`                                      |
+    | `service.annotations`                       | Service annotations              | `nil`                                      |
+    | `service.loadBalancerSourceRanges`          | Service LoadBalancer source IP whitelist | `nil`                              |
+    | `service.targetPort`                        | Service port                     | `nil`                                      |
+    | `service.port`                              | Port for exposing service        | `nil`                                      |
+    | `route.enabled`         | Set to true to create route for additional service | `false` |
+    | `route.name`            | Name of route                                      | `docker` |
+    | `route.portName`        | Target port name of service                        | `docker` |
+    | `route.labels`          | Labels to be added to route                        | `{}` |
+    | `route.annotations`     | Annotations to be added to route                   | `{}` |
+    | `route.path`            | Host name of Route e.g jenkins.example.com         | nil |
+  displayName: Nexus Repository Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAHAAAACACAYAAADTcu1SAAAACXBIWXMAACE3AAAhNwEzWJ96AAAHQklEQVR4nO2dMXLbOBSGXzLb2/1yJqzJIr5BnNpFfIP1DaJC/cq9ZyyfIPIJohSqbZ3ASiG3lmd0gNUJvAPNTy9XpCQSBB7wQHwzKWIqMcWfxA/8APE+vL29UUgkaX5KROP1anm1+7Wy2XBARNPni5tVKF/5Y+UngknSfERESpy/9nyLSyJaZLPhKJsNTytHBRKEgEmanydproT7m4hOKh/4Pyf4nBKy8pRKQ7SASZqnSZo/EtEDEX2qfOAw6vM/stnwMZsNzw5+0mNECqh8LknzMRG9ENGXygfaof79UzYbTiQ2q+IETNJ8AJ/7XjnYDeWbK+WP3N+pC2IEhM8tiOi2gc/psvXHbDZUQp7b/1bd+cP3E1Q+p4YFRPStctAeyh8fstlwTkRXPg87vH0C4XMj+ByneGWUP75ks+HYV3/0UsAkzVX3foHuvg98hz8OPDmfd7wSED6nhgU/NIYFtlH+eJvNhguf/NELATGem2A813VYYJvP8MdpNhumrk/GuYDwucWB+MtXvsEfncZyzgRM0vyyRfzlM05jOXYBkzQ/g8/99NDndCnHcqz+yCZgKf56EuBzunyBP7LFciwCWoy/9nG95+dTItpUfmoetljO6oSuGhYQ0YSxqfxFRIP1ark3OcGTMWbsNL2qc3q+uJlWjhjAioCIvyaMTeVvCPdYObIHeNWI8RznEHJROdIBowJiOcOAMUFRzeFovVqOK0cagt7jiLGVuFO/7/ni5p/KEQ2MCYj4a8w4JNheiPVq2flCoFllv/GeL260b7yCzgLC58ZIKDjYzhAc8jldkKxwzny8YrajcdO/i7aA8LkRd2dgvVpa6QyUgT9y3pS/4I+tb8rWApZ8bsDUXG6wTJB9phyzDyNGW1DDn3Ebf2wlIHyO0/Dv8dQZMXwd4I8jxjHsBk/jpHKkhkYCqvgLTQprl3u9WhrtcncB/sg5NJqjo3PQHw8KWKxyZvY51bNsdPe5AP7IGU7cQ8haf9wrIKZ5WH0OXuesuWwDYjL267PrjxUBfYy/fMWHWO5dQAnxl69gZTdnH+Hu+eJmuz7nw5+fMie9LJ99TheGWK7SlCoBz7EWhYNrST6nQymWM+2PtZ0ZLgGtxV++YjCW+w3fq7Ua2wK+QrjaX94HOsRyjQb0tgTsPM0TGvDHprM1RyO1Iou2IaDz+MtXGsRyR9/F2M2iTQroXfzlKzWxXKNpJbUUE0/xey/XhIBs0zyhAX9Mj/ncoSy6i4DOpnn6QpMsusuywkUUzx6lpZh7xSMJL3j2jbZZdBTQE3Sz6KA2+hGO1kRCFFA4UUDhRAGFEzsxADFXseXW4lAO6RNBCIig+Nj76o+7URVEu8Kf8mzBV/X5yv/gIaE8gVcNe3BbUSxOurLTuyYU61emobze3atODJrap4Deze/VE3jJ+LIKG316AoMTj+I4UD5RQOH0fSD/iqHFCtt9qbHkKf4ugr4KOMeqL/HLQPom4AaLh4JZv9MnAZV456b3aXFNnzox49DEo9gLlU8UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUThRQOFFA4UQBhRMFFE4UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUTijLCicN3qgNcs/SIARsWuUkRGITKpwooHCigMKJAgqni4Bn2NMy0gHU19cuxtxFQLW/ym2S5ivscRlpCeoxLrrU7jUxjFBbdjwkad674h664IY3UgLdpAeqk3lJ0nyMvZ4jO6C5nGCPciOFsmx0YlRNhBWahwiAzx3dA7sttkvvBFNiTpe6Wg8msT2M+Ax/nGJP6N6gaj0kaa5u3J82t/biGgeqCl4L1YyE7o/wuTH2ZLNeEPIjurH3lSPmOUF3eRGqP5ZqPeyrjWSa63IJ1r3lXSwxR4Uz8f7osu5wXRFkq6Zbg9hqZ/B1E0Uem1Kpx1gRkGpKnFU+YB5RdZhK10c7QWnJ3nqMtQKWTjRFYsBaZtvnSmjw76aFHE1wB/FqW6iDApZOWreMqC7exXIm46+GNLoGjQQs8O3u48D3VqiVgORZ+28TKf2A1gIW+NADs4Wknri2gAUux0CVIx2ROBbuLGABUogRoz9uS3Wb8McmpU4N8wrhOi+HNCYg/XchDpXZNs0GT6P2hWC+8Ta4UYzceGRawAIJTVEoTb8VAQscdQZGhy6SbqnTDlidE7UqYAFmo1m747vNlMTmvQksApK7jsJ2QBxyAMEmYIGDSGrDKBx7BMguYAGeilEglcTYQoZdnAlIbmI50zifBnMqYIGDWM4EXkxEeyFggYNpKx3mEM6LGhReCVjgoNfYBC8nm718vQxjpxTdcddskLue+bhSwMsnsIyD5KTM0WTHNd4LWMCcXYp5JUCMgAWWYzmW+Msk4gQke7GcsflFTkQKWGBo2sraDD8HogUs0Jy2chZ/mSQIAandKjInq9xsEYyABUfWcTpfZ2qa4AQs2InlvIq/TBKsgAWqoxOicFuI6F87l4XLuRPd1QAAAABJRU5ErkJggg==
+    mediatype: "image/png"
+  install:
+    spec:
+      deployments:
+      - name: nxrm-operator-certified
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: nxrm-operator-certified
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: nxrm-operator-certified
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: nxrm-operator-certified
+                - name: RELATED_IMAGE_NEXUS
+                  value: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.31.1-ubi-2
+                image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.31.1-1
+                imagePullPolicy: Always
+                name: nxrm-operator-certified
+                resources: {}
+              serviceAccountName: nxrm-operator-certified
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - nxrm-operator-certified
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - sonatype.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: nxrm-operator-certified
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - repository
+  - sonatype
+  links:
+  - name: Nexus Repository Manager
+    url: https://www.sonatype.com/product-nexus-repository
+  maintainers:
+  - email: support@sonatype.com
+    name: Sonatype
+  maturity: stable
+  provider:
+    name: Sonatype
+  version: 3.31.1-1
+  replaces: nxrm-operator-certified.v3.30.0-1

--- a/deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
@@ -1,6 +1,6 @@
 # DO NOT MODIFY. This is produced by template.
 channels:
-- currentCSV: nxrm-operator-certified.v3.30.0-1
+- currentCSV: nxrm-operator-certified.v3.31.1-1
   name: stable
 defaultChannel: stable
 packageName: nxrm-operator-certified

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: nxrm-operator-certified
           # Replace this with the built image name
-          image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.30.0-1
+          image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.31.1-1
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -31,4 +31,4 @@ spec:
             - name: OPERATOR_NAME
               value: "nxrm-operator-certified"
             - name: RELATED_IMAGE_NEXUS
-              value: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.30.0-ubi-1
+              value: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.31.1-ubi-2

--- a/helm-charts/sonatype-nexus/Chart.yaml
+++ b/helm-charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 # DO NOT MODIFY. This is produced by template.
 apiVersion: v1
-appVersion: 3.30.0
+appVersion: 3.31.1
 description: Sonatype Nexus is an open source repository manager
 home: https://www.sonatype.com/nexus-repository-oss
 icon: https://www.sonatype.com/hubfs/2019%20Horizontal%20Product%20logo/horizontal%20Repo%20/Repo/NexusRepo_horiz.svg

--- a/helm-charts/sonatype-nexus/values.yaml
+++ b/helm-charts/sonatype-nexus/values.yaml
@@ -32,7 +32,7 @@ nexus:
   - name: NEXUS_SECURITY_RANDOMPASSWORD
     value: "false"
   hostAliases: []
-  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.30.0-ubi-1
+  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.31.1-ubi-2
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   livenessProbe:


### PR DESCRIPTION
Upgrade operator to deploy nxrm 3.31.1. This is produced automatically by `scripts/new_version.sh`, and takes advantage of the removal of fsGroup.

JIRA: https://issues.sonatype.org/browse/INT-5337
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/operator-nxrm3/job/feature-snapshots/job/INT-5337-upgrade-3.31.1/