### PR TITLE
INT-6258 generate image and bundle files in new structure

### DIFF
--- a/scripts/new_version.sh
+++ b/scripts/new_version.sh
@@ -4,7 +4,7 @@ if [ $# -lt 1 ]; then
     echo "Usage: $0 image <operatorVersion> <certAppVersion>"
     echo "Usage: $0 bundle <operatorVersion> <operatorImageSHA> <certAppImageSHA>"
     echo "Ex: $0 image 3.20.0-1 3.20.0-ubi-1"
-    echo "Ex: $0 bundle 3.20.0-1 sha256:... sha256:... "
+    echo "Ex: $0 bundle 3.20.0-1 registry...@sha256:ab12... registry...@sha256:ab12..."
     exit 1
 fi
 
@@ -42,7 +42,7 @@ fi
 if [ "$1" = "bundle" ]; then
     if [ $# -ne 4 ]; then
         echo "Usage: $0 bundle <operatorVersion> <operatorImageSHA> <certAppImageSHA>"
-        echo "Ex: $0 bundle 3.20.0-1 ab2332... cef332..."
+        echo "Ex: $0 bundle 3.20.0-1 registry...@sha256:ab12... registry...@sha256:ab12..."
         exit 1
     fi
 

--- a/scripts/new_version.sh
+++ b/scripts/new_version.sh
@@ -42,7 +42,7 @@ fi
 if [ "$1" = "bundle" ]; then
     if [ $# -ne 4 ]; then
         echo "Usage: $0 bundle <operatorVersion> <operatorImageSHA> <certAppImageSHA>"
-        echo "Ex: $0 bundle 3.20.0-1 sha256:... sha256:... "
+        echo "Ex: $0 bundle 3.20.0-1 ab2332... cef332..."
         exit 1
     fi
 

--- a/scripts/new_version.sh
+++ b/scripts/new_version.sh
@@ -23,10 +23,10 @@ if [ "$1" = "image" ]; then
     certAppVersion=$3
 
     function applyTemplate {
-        sed "s/{{shortVersion}}/${shortVersion}/g" \
-        | sed "s/{{certAppVersion}}/${certAppVersion}/g" \
-        | sed "s/{{operatorVersion}}/${operatorVersion}/g" \
-        | sed "s/{{templateWarning}}/DO NOT MODIFY. This is produced by template./g"
+        sed "s!{{shortVersion}}!${shortVersion}!g" \
+        | sed "s!{{certAppVersion}}!${certAppVersion}!g" \
+        | sed "s!{{operatorVersion}}!${operatorVersion}!g" \
+        | sed "s!{{templateWarning}}!DO NOT MODIFY. This is produced by template.!g"
     }
 
     cat scripts/templates/Chart.yaml \
@@ -51,11 +51,11 @@ if [ "$1" = "bundle" ]; then
     certAppSHA=$4
 
     function applyTemplate {
-        sed "s/{{shortVersion}}/${shortVersion}/g" \
-        | sed "s/{{certAppSHA}}/${certAppSHA}/g" \
-        | sed "s/{{operatorSHA}}/${operatorSHA}/g" \
-        | sed "s/{{operatorVersion}}/${operatorVersion}/g" \
-        | sed "s/{{templateWarning}}/DO NOT MODIFY. This is produced by template./g"
+        sed "s!{{shortVersion}}!${shortVersion}!g" \
+        | sed "s!{{certAppSHA}}!${certAppSHA}!g" \
+        | sed "s!{{operatorSHA}}!${operatorSHA}!g" \
+        | sed "s!{{operatorVersion}}!${operatorVersion}!g" \
+        | sed "s!{{templateWarning}}!DO NOT MODIFY. This is produced by template.!g"
     }
 
     cat scripts/templates/nxrm-operator-certified.package.yaml \

--- a/scripts/new_version.sh
+++ b/scripts/new_version.sh
@@ -1,49 +1,88 @@
 #!/bin/sh
 
-if [ $# != 2 ]; then
-    echo "Usage: $0 <operatorVersion> <certAppVersion>"
-    echo "Ex: $0 3.20.0-1 3.20.0-ubi-1"
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 image <operatorVersion> <certAppVersion>"
+    echo "Usage: $0 bundle <operatorVersion> <operatorImageSHA> <certAppImageSHA>"
+    echo "Ex: $0 image 3.20.0-1 3.20.0-ubi-1"
+    echo "Ex: $0 bundle 3.20.0-1 sha256:... sha256:... "
     exit 1
 fi
 
-operatorVersion=$1
-certAppVersion=$2
+stage=$1
 
-shortVersion=$(echo $1 | sed 's/-.*//')
-replacedOperatorVersion=$(cat \
-    deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml \
-    | grep currentCSV: | sed 's/.*v//')
+shortVersion=$(echo $2 | sed 's/-.*//')
 
-function applyTemplate {
-    sed "s/{{shortVersion}}/${shortVersion}/g" \
-    | sed "s/{{certAppVersion}}/${certAppVersion}/g" \
-    | sed "s/{{operatorVersion}}/${operatorVersion}/g" \
-    | sed "s/{{replacedOperatorVersion}}/${replacedOperatorVersion}/g" \
-    | sed "s/{{templateWarning}}/DO NOT MODIFY. This is produced by template./g"
-}
+if [ "$1" = "image" ]; then
+    if [ $# -ne 3 ]; then
+        echo "Usage: $0 image <operatorVersion> <certAppVersion>"
+        echo "Ex: $0 image 3.20.0-1 3.20.0-ubi-1"
+        exit 1
+    fi
 
-cat scripts/templates/Chart.yaml \
-    | applyTemplate > helm-charts/sonatype-nexus/Chart.yaml
+    operatorVersion=$2
+    certAppVersion=$3
 
-cat scripts/templates/Dockerfile \
-    | applyTemplate > build/Dockerfile
+    function applyTemplate {
+        sed "s/{{shortVersion}}/${shortVersion}/g" \
+        | sed "s/{{certAppVersion}}/${certAppVersion}/g" \
+        | sed "s/{{operatorVersion}}/${operatorVersion}/g" \
+        | sed "s/{{templateWarning}}/DO NOT MODIFY. This is produced by template./g"
+    }
 
-cat scripts/templates/nxrm-operator-certified.package.yaml \
-    | applyTemplate \
-    > deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
+    cat scripts/templates/Chart.yaml \
+        | applyTemplate > helm-charts/sonatype-nexus/Chart.yaml
 
-if [ ! -d "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}" ]; then
-    mkdir "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}"
+    cat scripts/templates/values.yaml \
+        | applyTemplate > helm-charts/sonatype-nexus/values.yaml
+
+    cat scripts/templates/Dockerfile \
+        | applyTemplate > build/Dockerfile
 fi
 
-cat scripts/templates/nxrm-operator-certified.vX.X.X-X.clusterserviceversion.yaml \
-    | applyTemplate \
-    > "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/nxrm-operator-certified.v${operatorVersion}.clusterserviceversion.yaml"
+if [ "$1" = "bundle" ]; then
+    if [ $# -ne 4 ]; then
+        echo "Usage: $0 bundle <operatorVersion> <operatorImageSHA> <certAppImageSHA>"
+        echo "Ex: $0 bundle 3.20.0-1 sha256:... sha256:... "
+        exit 1
+    fi
 
-cat scripts/templates/operator.yaml | applyTemplate > deploy/operator.yaml
+    operatorVersion=$2
+    operatorSHA=$3
+    certAppSHA=$4
 
-cat scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml \
-    | applyTemplate > deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+    function applyTemplate {
+        sed "s/{{shortVersion}}/${shortVersion}/g" \
+        | sed "s/{{certAppSHA}}/${certAppSHA}/g" \
+        | sed "s/{{operatorSHA}}/${operatorSHA}/g" \
+        | sed "s/{{operatorVersion}}/${operatorVersion}/g" \
+        | sed "s/{{templateWarning}}/DO NOT MODIFY. This is produced by template./g"
+    }
 
-cat scripts/templates/values.yaml \
-    | applyTemplate > helm-charts/sonatype-nexus/values.yaml
+    cat scripts/templates/nxrm-operator-certified.package.yaml \
+        | applyTemplate \
+        > deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
+
+    [ ! -d "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/manifests" ] \
+        && mkdir -p "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/manifests"
+
+    [ ! -d "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/metadata" ] \
+        && mkdir -p "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/metadata"
+
+    cat scripts/templates/annotations.yaml \
+        | applyTemplate \
+        > "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/metadata/annotations.yaml"
+
+    cat scripts/templates/nxrm-operator-certified.clusterserviceversion.yaml \
+        | applyTemplate \
+        > "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/manifests/nxrm-operator-certified.clusterserviceversion.yaml"
+
+    cat scripts/templates/sonatype.com_nexusrepos_crd.yaml \
+        | applyTemplate \
+        > "deploy/olm-catalog/nxrm-operator-certified/${operatorVersion}/manifests/sonatype.com_nexusrepos_crd.yaml"
+
+    cat scripts/templates/operator.yaml | applyTemplate > deploy/operator.yaml
+
+    cat scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml \
+        | applyTemplate > deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+
+fi

--- a/scripts/templates/annotations.yaml
+++ b/scripts/templates/annotations.yaml
@@ -1,0 +1,9 @@
+---
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: nxrm-operator-certified
+  com.redhat.openshift.versions: v4.6-v4.9

--- a/scripts/templates/nxrm-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxrm-operator-certified.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
                 }
               ],
               "hostAliases": [],
-              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}",
+              "imageName": "{{certAppSHA}}",
               "imagePullPolicy": "IfNotPresent",
               "imagePullSecret": "",
               "livenessProbe": {
@@ -128,7 +128,7 @@ metadata:
     description: |-
       Nexus Repository is the central source of control to efficiently manage all binaries
       and build artifacts across your DevOps pipeline.
-    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
+    containerImage: {{operatorSHA}}
     repository: https://github.com/sonatype/operator-nxrm3
     createdAt: 2020-07-17
     support: Sonatype
@@ -276,8 +276,8 @@ spec:
                       - name: OPERATOR_NAME
                         value: nxrm-operator-certified
                       - name: RELATED_IMAGE_NEXUS
-                        value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}
-                    image: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
+                        value: {{certAppSHA}}
+                    image: {{operatorSHA}}
                     imagePullPolicy: Always
                     name: nxrm-operator-certified
                     resources: {}

--- a/scripts/templates/nxrm-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxrm-operator-certified.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
                 }
               ],
               "hostAliases": [],
-              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager:{{certAppVersion}}",
+              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}",
               "imagePullPolicy": "IfNotPresent",
               "imagePullSecret": "",
               "livenessProbe": {
@@ -128,7 +128,7 @@ metadata:
     description: |-
       Nexus Repository is the central source of control to efficiently manage all binaries
       and build artifacts across your DevOps pipeline.
-    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified:{{operatorVersion}}
+    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
     repository: https://github.com/sonatype/operator-nxrm3
     createdAt: 2020-07-17
     support: Sonatype
@@ -276,8 +276,8 @@ spec:
                       - name: OPERATOR_NAME
                         value: nxrm-operator-certified
                       - name: RELATED_IMAGE_NEXUS
-                        value: registry.connect.redhat.com/sonatype/nexus-repository-manager:{{certAppVersion}}
-                    image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:{{operatorVersion}}
+                        value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}
+                    image: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
                     imagePullPolicy: Always
                     name: nxrm-operator-certified
                     resources: {}

--- a/scripts/templates/operator.yaml
+++ b/scripts/templates/operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: nxrm-operator-certified
           # Replace this with the built image name
-          image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:{{operatorVersion}}
+          image: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -32,4 +32,4 @@ spec:
             - name: OPERATOR_NAME
               value: "nxrm-operator-certified"
             - name: RELATED_IMAGE_NEXUS
-              value: registry.connect.redhat.com/sonatype/nexus-repository-manager:{{certAppVersion}}
+              value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}

--- a/scripts/templates/operator.yaml
+++ b/scripts/templates/operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: nxrm-operator-certified
           # Replace this with the built image name
-          image: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:{{operatorSHA}}
+          image: {{operatorSHA}}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -32,4 +32,4 @@ spec:
             - name: OPERATOR_NAME
               value: "nxrm-operator-certified"
             - name: RELATED_IMAGE_NEXUS
-              value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}
+              value: {{certAppSHA}}

--- a/scripts/templates/sonatype.com_nexusrepos_crd.yaml
+++ b/scripts/templates/sonatype.com_nexusrepos_crd.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nexusrepos.sonatype.com
+spec:
+  group: sonatype.com
+  names:
+    kind: NexusRepo
+    listKind: NexusRepoList
+    plural: nexusrepos
+    singular: nexusrepo
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: NexusRepo is the Schema for the nexusrepos API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of NexusRepo
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status defines the observed state of NexusRepo
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+++ b/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
@@ -40,7 +40,7 @@ spec:
       - name: NEXUS_SECURITY_RANDOMPASSWORD
         value: "false"
     hostAliases: []
-    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}
+    imageName: {{certAppSHA}}
     imagePullPolicy: IfNotPresent
     imagePullSecret: ""
     livenessProbe:

--- a/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+++ b/scripts/templates/sonatype.com_v1alpha1_nexusrepo_cr.yaml
@@ -40,7 +40,7 @@ spec:
       - name: NEXUS_SECURITY_RANDOMPASSWORD
         value: "false"
     hostAliases: []
-    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:{{certAppVersion}}
+    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:{{certAppSHA}}
     imagePullPolicy: IfNotPresent
     imagePullSecret: ""
     livenessProbe:


### PR DESCRIPTION
* image files produced separately with regular versions
* bundle generated after images are available with sha256 as required by openshift

JIRA: https://issues.sonatype.org/browse/INT-6258

I'll next be updating docs for the process that uses this script: https://docs.sonatype.com/pages/viewpage.action?pageId=172133164