### PR TITLE
INT-6258 replace 3.35.0 with regenerated bundle that was really deployed

### DIFF
--- a/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/manifests/nxrm-operator-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/manifests/nxrm-operator-certified.clusterserviceversion.yaml
@@ -1,4 +1,5 @@
 # DO NOT MODIFY. This is produced by template.
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
@@ -55,7 +56,7 @@ metadata:
                 }
               ],
               "hostAliases": [],
-              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager:3.35.0-ubi-1",
+              "imageName": "registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:9dafcabb682b0f361a7368dcce6d1589a7229c1558fc884fbd2f45113b7db18e",
               "imagePullPolicy": "IfNotPresent",
               "imagePullSecret": "",
               "livenessProbe": {
@@ -127,7 +128,7 @@ metadata:
     description: |-
       Nexus Repository is the central source of control to efficiently manage all binaries
       and build artifacts across your DevOps pipeline.
-    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.35.0-1
+    containerImage: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:dc422f87e7fa54aadd83ed1f5b167bb7a47c69562eb736f6dedd586067d40b70
     repository: https://github.com/sonatype/operator-nxrm3
     createdAt: 2020-07-17
     support: Sonatype
@@ -171,7 +172,7 @@ spec:
     ## Limitations
 
     High Availability Clustering (HA-C) is not supported for Nexus Repository Pro for OpenShift.
-    
+
     This operator will be released on a quarterly basis.
 
     ## Usage
@@ -245,136 +246,136 @@ spec:
     | `route.path`            | Host name of Route e.g jenkins.example.com         | nil |
   displayName: Nexus Repository Operator
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAHAAAACACAYAAADTcu1SAAAACXBIWXMAACE3AAAhNwEzWJ96AAAHQklEQVR4nO2dMXLbOBSGXzLb2/1yJqzJIr5BnNpFfIP1DaJC/cq9ZyyfIPIJohSqbZ3ASiG3lmd0gNUJvAPNTy9XpCQSBB7wQHwzKWIqMcWfxA/8APE+vL29UUgkaX5KROP1anm1+7Wy2XBARNPni5tVKF/5Y+UngknSfERESpy/9nyLSyJaZLPhKJsNTytHBRKEgEmanydproT7m4hOKh/4Pyf4nBKy8pRKQ7SASZqnSZo/EtEDEX2qfOAw6vM/stnwMZsNzw5+0mNECqh8LknzMRG9ENGXygfaof79UzYbTiQ2q+IETNJ8AJ/7XjnYDeWbK+WP3N+pC2IEhM8tiOi2gc/psvXHbDZUQp7b/1bd+cP3E1Q+p4YFRPStctAeyh8fstlwTkRXPg87vH0C4XMj+ByneGWUP75ks+HYV3/0UsAkzVX3foHuvg98hz8OPDmfd7wSED6nhgU/NIYFtlH+eJvNhguf/NELATGem2A813VYYJvP8MdpNhumrk/GuYDwucWB+MtXvsEfncZyzgRM0vyyRfzlM05jOXYBkzQ/g8/99NDndCnHcqz+yCZgKf56EuBzunyBP7LFciwCWoy/9nG95+dTItpUfmoetljO6oSuGhYQ0YSxqfxFRIP1ark3OcGTMWbsNL2qc3q+uJlWjhjAioCIvyaMTeVvCPdYObIHeNWI8RznEHJROdIBowJiOcOAMUFRzeFovVqOK0cagt7jiLGVuFO/7/ni5p/KEQ2MCYj4a8w4JNheiPVq2flCoFllv/GeL260b7yCzgLC58ZIKDjYzhAc8jldkKxwzny8YrajcdO/i7aA8LkRd2dgvVpa6QyUgT9y3pS/4I+tb8rWApZ8bsDUXG6wTJB9phyzDyNGW1DDn3Ebf2wlIHyO0/Dv8dQZMXwd4I8jxjHsBk/jpHKkhkYCqvgLTQprl3u9WhrtcncB/sg5NJqjo3PQHw8KWKxyZvY51bNsdPe5AP7IGU7cQ8haf9wrIKZ5WH0OXuesuWwDYjL267PrjxUBfYy/fMWHWO5dQAnxl69gZTdnH+Hu+eJmuz7nw5+fMie9LJ99TheGWK7SlCoBz7EWhYNrST6nQymWM+2PtZ0ZLgGtxV++YjCW+w3fq7Ua2wK+QrjaX94HOsRyjQb0tgTsPM0TGvDHprM1RyO1Iou2IaDz+MtXGsRyR9/F2M2iTQroXfzlKzWxXKNpJbUUE0/xey/XhIBs0zyhAX9Mj/ncoSy6i4DOpnn6QpMsusuywkUUzx6lpZh7xSMJL3j2jbZZdBTQE3Sz6KA2+hGO1kRCFFA4UUDhRAGFEzsxADFXseXW4lAO6RNBCIig+Nj76o+7URVEu8Kf8mzBV/X5yv/gIaE8gVcNe3BbUSxOurLTuyYU61emobze3atODJrap4Deze/VE3jJ+LIKG316AoMTj+I4UD5RQOH0fSD/iqHFCtt9qbHkKf4ugr4KOMeqL/HLQPom4AaLh4JZv9MnAZV456b3aXFNnzox49DEo9gLlU8UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUThRQOFFA4UQBhRMFFE4UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUTijLCicN3qgNcs/SIARsWuUkRGITKpwooHCigMKJAgqni4Bn2NMy0gHU19cuxtxFQLW/ym2S5ivscRlpCeoxLrrU7jUxjFBbdjwkad674h664IY3UgLdpAeqk3lJ0nyMvZ4jO6C5nGCPciOFsmx0YlRNhBWahwiAzx3dA7sttkvvBFNiTpe6Wg8msT2M+Ax/nGJP6N6gaj0kaa5u3J82t/biGgeqCl4L1YyE7o/wuTH2ZLNeEPIjurH3lSPmOUF3eRGqP5ZqPeyrjWSa63IJ1r3lXSwxR4Uz8f7osu5wXRFkq6Zbg9hqZ/B1E0Uem1Kpx1gRkGpKnFU+YB5RdZhK10c7QWnJ3nqMtQKWTjRFYsBaZtvnSmjw76aFHE1wB/FqW6iDApZOWreMqC7exXIm46+GNLoGjQQs8O3u48D3VqiVgORZ+28TKf2A1gIW+NADs4Wknri2gAUux0CVIx2ROBbuLGABUogRoz9uS3Wb8McmpU4N8wrhOi+HNCYg/XchDpXZNs0GT6P2hWC+8Ta4UYzceGRawAIJTVEoTb8VAQscdQZGhy6SbqnTDlidE7UqYAFmo1m747vNlMTmvQksApK7jsJ2QBxyAMEmYIGDSGrDKBx7BMguYAGeilEglcTYQoZdnAlIbmI50zifBnMqYIGDWM4EXkxEeyFggYNpKx3mEM6LGhReCVjgoNfYBC8nm718vQxjpxTdcddskLue+bhSwMsnsIyD5KTM0WTHNd4LWMCcXYp5JUCMgAWWYzmW+Msk4gQke7GcsflFTkQKWGBo2sraDD8HogUs0Jy2chZ/mSQIAandKjInq9xsEYyABUfWcTpfZ2qa4AQs2InlvIq/TBKsgAWqoxOicFuI6F87l4XLuRPd1QAAAABJRU5ErkJggg==
-    mediatype: "image/png"
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAHAAAACACAYAAADTcu1SAAAACXBIWXMAACE3AAAhNwEzWJ96AAAHQklEQVR4nO2dMXLbOBSGXzLb2/1yJqzJIr5BnNpFfIP1DaJC/cq9ZyyfIPIJohSqbZ3ASiG3lmd0gNUJvAPNTy9XpCQSBB7wQHwzKWIqMcWfxA/8APE+vL29UUgkaX5KROP1anm1+7Wy2XBARNPni5tVKF/5Y+UngknSfERESpy/9nyLSyJaZLPhKJsNTytHBRKEgEmanydproT7m4hOKh/4Pyf4nBKy8pRKQ7SASZqnSZo/EtEDEX2qfOAw6vM/stnwMZsNzw5+0mNECqh8LknzMRG9ENGXygfaof79UzYbTiQ2q+IETNJ8AJ/7XjnYDeWbK+WP3N+pC2IEhM8tiOi2gc/psvXHbDZUQp7b/1bd+cP3E1Q+p4YFRPStctAeyh8fstlwTkRXPg87vH0C4XMj+ByneGWUP75ks+HYV3/0UsAkzVX3foHuvg98hz8OPDmfd7wSED6nhgU/NIYFtlH+eJvNhguf/NELATGem2A813VYYJvP8MdpNhumrk/GuYDwucWB+MtXvsEfncZyzgRM0vyyRfzlM05jOXYBkzQ/g8/99NDndCnHcqz+yCZgKf56EuBzunyBP7LFciwCWoy/9nG95+dTItpUfmoetljO6oSuGhYQ0YSxqfxFRIP1ark3OcGTMWbsNL2qc3q+uJlWjhjAioCIvyaMTeVvCPdYObIHeNWI8RznEHJROdIBowJiOcOAMUFRzeFovVqOK0cagt7jiLGVuFO/7/ni5p/KEQ2MCYj4a8w4JNheiPVq2flCoFllv/GeL260b7yCzgLC58ZIKDjYzhAc8jldkKxwzny8YrajcdO/i7aA8LkRd2dgvVpa6QyUgT9y3pS/4I+tb8rWApZ8bsDUXG6wTJB9phyzDyNGW1DDn3Ebf2wlIHyO0/Dv8dQZMXwd4I8jxjHsBk/jpHKkhkYCqvgLTQprl3u9WhrtcncB/sg5NJqjo3PQHw8KWKxyZvY51bNsdPe5AP7IGU7cQ8haf9wrIKZ5WH0OXuesuWwDYjL267PrjxUBfYy/fMWHWO5dQAnxl69gZTdnH+Hu+eJmuz7nw5+fMie9LJ99TheGWK7SlCoBz7EWhYNrST6nQymWM+2PtZ0ZLgGtxV++YjCW+w3fq7Ua2wK+QrjaX94HOsRyjQb0tgTsPM0TGvDHprM1RyO1Iou2IaDz+MtXGsRyR9/F2M2iTQroXfzlKzWxXKNpJbUUE0/xey/XhIBs0zyhAX9Mj/ncoSy6i4DOpnn6QpMsusuywkUUzx6lpZh7xSMJL3j2jbZZdBTQE3Sz6KA2+hGO1kRCFFA4UUDhRAGFEzsxADFXseXW4lAO6RNBCIig+Nj76o+7URVEu8Kf8mzBV/X5yv/gIaE8gVcNe3BbUSxOurLTuyYU61emobze3atODJrap4Deze/VE3jJ+LIKG316AoMTj+I4UD5RQOH0fSD/iqHFCtt9qbHkKf4ugr4KOMeqL/HLQPom4AaLh4JZv9MnAZV456b3aXFNnzox49DEo9gLlU8UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUThRQOFFA4UQBhRMFFE4UUDhRQOFEAYUTBRROFFA4UUDhRAGFEwUUTijLCicN3qgNcs/SIARsWuUkRGITKpwooHCigMKJAgqni4Bn2NMy0gHU19cuxtxFQLW/ym2S5ivscRlpCeoxLrrU7jUxjFBbdjwkad674h664IY3UgLdpAeqk3lJ0nyMvZ4jO6C5nGCPciOFsmx0YlRNhBWahwiAzx3dA7sttkvvBFNiTpe6Wg8msT2M+Ax/nGJP6N6gaj0kaa5u3J82t/biGgeqCl4L1YyE7o/wuTH2ZLNeEPIjurH3lSPmOUF3eRGqP5ZqPeyrjWSa63IJ1r3lXSwxR4Uz8f7osu5wXRFkq6Zbg9hqZ/B1E0Uem1Kpx1gRkGpKnFU+YB5RdZhK10c7QWnJ3nqMtQKWTjRFYsBaZtvnSmjw76aFHE1wB/FqW6iDApZOWreMqC7exXIm46+GNLoGjQQs8O3u48D3VqiVgORZ+28TKf2A1gIW+NADs4Wknri2gAUux0CVIx2ROBbuLGABUogRoz9uS3Wb8McmpU4N8wrhOi+HNCYg/XchDpXZNs0GT6P2hWC+8Ta4UYzceGRawAIJTVEoTb8VAQscdQZGhy6SbqnTDlidE7UqYAFmo1m747vNlMTmvQksApK7jsJ2QBxyAMEmYIGDSGrDKBx7BMguYAGeilEglcTYQoZdnAlIbmI50zifBnMqYIGDWM4EXkxEeyFggYNpKx3mEM6LGhReCVjgoNfYBC8nm718vQxjpxTdcddskLue+bhSwMsnsIyD5KTM0WTHNd4LWMCcXYp5JUCMgAWWYzmW+Msk4gQke7GcsflFTkQKWGBo2sraDD8HogUs0Jy2chZ/mSQIAandKjInq9xsEYyABUfWcTpfZ2qa4AQs2InlvIq/TBKsgAWqoxOicFuI6F87l4XLuRPd1QAAAABJRU5ErkJggg==
+      mediatype: "image/png"
   install:
     spec:
       deployments:
-      - name: nxrm-operator-certified
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: nxrm-operator-certified
-          strategy: {}
-          template:
-            metadata:
-              labels:
+        - name: nxrm-operator-certified
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: nxrm-operator-certified
-            spec:
-              containers:
-              - env:
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: OPERATOR_NAME
-                  value: nxrm-operator-certified
-                - name: RELATED_IMAGE_NEXUS
-                  value: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.35.0-ubi-1
-                image: registry.connect.redhat.com/sonatype/nxrm-operator-certified:3.35.0-1
-                imagePullPolicy: Always
-                name: nxrm-operator-certified
-                resources: {}
-              serviceAccountName: nxrm-operator-certified
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: nxrm-operator-certified
+              spec:
+                containers:
+                  - env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: nxrm-operator-certified
+                      - name: RELATED_IMAGE_NEXUS
+                        value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:9dafcabb682b0f361a7368dcce6d1589a7229c1558fc884fbd2f45113b7db18e
+                    image: registry.connect.redhat.com/sonatype/nxrm-operator-certified@sha256:dc422f87e7fa54aadd83ed1f5b167bb7a47c69562eb736f6dedd586067d40b70
+                    imagePullPolicy: Always
+                    name: nxrm-operator-certified
+                    resources: {}
+                serviceAccountName: nxrm-operator-certified
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - services
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - apps
-          resourceNames:
-          - nxrm-operator-certified
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-        - apiGroups:
-          - sonatype.com
-          resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        serviceAccountName: nxrm-operator-certified
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - secrets
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
+                - nxrm-operator-certified
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+                - deployments
+              verbs:
+                - get
+            - apiGroups:
+                - sonatype.com
+              resources:
+                - '*'
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          serviceAccountName: nxrm-operator-certified
     strategy: deployment
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: true
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - repository
-  - sonatype
+    - repository
+    - sonatype
   links:
-  - name: Nexus Repository Manager
-    url: https://www.sonatype.com/product-nexus-repository
+    - name: Nexus Repository Manager
+      url: https://www.sonatype.com/product-nexus-repository
   maintainers:
-  - email: support@sonatype.com
-    name: Sonatype
+    - email: support@sonatype.com
+      name: Sonatype
   maturity: stable
   provider:
     name: Sonatype

--- a/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/manifests/sonatype.com_nexusrepos_crd.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/manifests/sonatype.com_nexusrepos_crd.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nexusrepos.sonatype.com
+spec:
+  group: sonatype.com
+  names:
+    kind: NexusRepo
+    listKind: NexusRepoList
+    plural: nexusrepos
+    singular: nexusrepo
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: NexusRepo is the Schema for the nexusrepos API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of NexusRepo
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status defines the observed state of NexusRepo
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/metadata/annotations.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/3.35.0-1/metadata/annotations.yaml
@@ -1,0 +1,9 @@
+---
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: nxrm-operator-certified
+  com.redhat.openshift.versions: v4.6-v4.9

--- a/deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
+++ b/deploy/olm-catalog/nxrm-operator-certified/nxrm-operator-certified.package.yaml
@@ -1,6 +1,7 @@
 # DO NOT MODIFY. This is produced by template.
+---
 channels:
-- currentCSV: nxrm-operator-certified.v3.35.0-1
-  name: stable
+  - currentCSV: nxrm-operator-certified.v3.35.0-1
+    name: stable
 defaultChannel: stable
 packageName: nxrm-operator-certified

--- a/helm-charts/sonatype-nexus/Chart.yaml
+++ b/helm-charts/sonatype-nexus/Chart.yaml
@@ -1,24 +1,25 @@
 # DO NOT MODIFY. This is produced by template.
+---
 apiVersion: v1
 appVersion: 3.35.0
 description: Sonatype Nexus is an open source repository manager
 home: https://www.sonatype.com/nexus-repository-oss
 icon: https://www.sonatype.com/hubfs/2019%20Horizontal%20Product%20logo/horizontal%20Repo%20/Repo/NexusRepo_horiz.svg
 keywords:
-- artifacts
-- dependency
-- management
-- sonatype
-- nexus
-- repository
-- quickstart
-- ci
-- repository-manager
-- nexus3
+  - artifacts
+  - dependency
+  - management
+  - sonatype
+  - nexus
+  - repository
+  - quickstart
+  - ci
+  - repository-manager
+  - nexus3
 maintainers:
-- email: support@sonatype.com
-  name: Sonatype
+  - email: support@sonatype.com
+    name: Sonatype
 name: sonatype-nexus
 sources:
-- https://github.com/sonatype/nexus-public
+  - https://github.com/sonatype/nexus-public
 version: 0.2.0

--- a/helm-charts/sonatype-nexus/values.yaml
+++ b/helm-charts/sonatype-nexus/values.yaml
@@ -1,4 +1,5 @@
 # DO NOT MODIFY. This is produced by template.
+---
 config:
   data: null
   enabled: false
@@ -26,11 +27,11 @@ ingress:
 nexus:
   dockerPort: 5003
   env:
-  - name: install4jAddVmParams
-    value: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions
-      -XX:+UseCGroupMemoryLimitForHeap
-  - name: NEXUS_SECURITY_RANDOMPASSWORD
-    value: "false"
+    - name: install4jAddVmParams
+      value: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions
+        -XX:+UseCGroupMemoryLimitForHeap
+    - name: NEXUS_SECURITY_RANDOMPASSWORD
+      value: "false"
   hostAliases: []
   imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.35.0-ubi-1
   imagePullPolicy: IfNotPresent
@@ -74,9 +75,9 @@ service:
   enabled: false
   labels: {}
   ports:
-  - name: nexus-service
-    port: 80
-    targetPort: 80
+    - name: nexus-service
+      port: 80
+      targetPort: 80
 statefulset:
   enabled: false
 tolerations: []


### PR DESCRIPTION
The old 3.35.0 metadata was copied from this project into the certified-operators project, fixed up to pass certification tests, and those changes were brought back into the templates of this project.  This PR updates the old bundle files we had to be the files that match those we submitted to red hat and published.

NOTE: this is built upon the previous PR, so i'll update it to merge to main after the other PR is merged.

JIRA: https://issues.sonatype.org/browse/INT-6258