### PR TITLE
INT-7341 use quay.io for red hat certification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,15 +24,16 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.4.0/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.4.1/preflight-linux-amd64
         chmod 755 preflight
       '''
     }
     stage('Build') {
       withCredentials([
-        string(
-          credentialsId: 'red-hat-scan-registry-password-nexus-repository-manager-operator',
-          variable: 'REGISTRY_PASSWORD'),
+        usernamePassword(
+          credentialsId: 'red-hat-quay-nexus-repository-manager-operator',
+          usernameVariable: 'REGISTRY_LOGIN',
+          passwordVariable: 'REGISTRY_PASSWORD'),
         string(
           credentialsId: 'red-hat-api-token',
           variable: 'API_TOKEN'),

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -38,7 +38,7 @@ IMAGE_TAG="${REPOSITORY}/redhat-isv-containers/${CERT_PROJECT_ID}:${VERSION}"
 AUTHFILE="${HOME}/.docker/config.json"
 
 docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" .
-       .
+
 docker login "${REPOSITORY}" \
         -u "${REGISTRY_LOGIN}" \
         --password "${REGISTRY_PASSWORD}"

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -20,34 +20,33 @@
 #   * https://github.com/redhat-openshift-ecosystem/openshift-preflight
 # * environment variables:
 #   * VERSION of the docker image  to build for the red hat registry
-#   * REGISTRY_PASSWORD from red hat config page for image
+#   * REGISTRY_LOGIN from Red Hat config page for image
+#   * REGISTRY_PASSWORD from Red Hat config page for image
 #   * API_TOKEN from red hat token/account page for API access
 
 set -x # log commands as they execute
 set -e # stop execution on the first failed command
 
-IMAGE=nxrm-operator-certified
 DOCKERFILE=build/Dockerfile
 
 # from config/scanning page at red hat
-PROJECT_ID=ospid-7f9c4310-4d85-4c8a-b00f-c5ca472a2b32
-# from url of project at red hat
 CERT_PROJECT_ID=5e8ce8acf2ef89b1acc26c93
+
+REPOSITORY="quay.io"
+IMAGE_TAG="${REPOSITORY}/redhat-isv-containers/${CERT_PROJECT_ID}:${VERSION}"
 
 AUTHFILE="${HOME}/.docker/config.json"
 
-docker build \
-       -f "${DOCKERFILE}" \
-       -t "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}" \
+docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" .
        .
-docker login scan.connect.redhat.com -u unused \
-       --password "${REGISTRY_PASSWORD}"
+docker login "${REPOSITORY}" \
+        -u "${REGISTRY_LOGIN}" \
+        --password "${REGISTRY_PASSWORD}"
 
-docker push \
-       "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}"
+docker push "${IMAGE_TAG}"
 
 preflight check container \
-          "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}" \
+          "${IMAGE_TAG}" \
           --docker-config="${AUTHFILE}" \
           --submit \
           --certification-project-id="${CERT_PROJECT_ID}" \


### PR DESCRIPTION
push to new quay.io repository.

JIRA: https://issues.sonatype.org/browse/INT-7341
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Red%20Hat/job/release-test/6/