### PR TITLE
INT-7537 don't try to specify user/group

### DIFF
--- a/helm-charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/helm-charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -64,9 +64,6 @@ spec:
           imagePullPolicy: {{ .Values.nexus.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            runAsUser: 200
-            runAsGroup: 200
             seccompProfile:
               type: RuntimeDefault
             capabilities:


### PR DESCRIPTION
remove the settings that try to hard-code a user/group. this will bring back a warning, so we'll need to investigate that further to see about a better solution that does't conflict with customer configurations.

JIRA: https://issues.sonatype.org/browse/INT-7537